### PR TITLE
Fixed root mean squared error computation

### DIFF
--- a/openfe/FeatureSelector.py
+++ b/openfe/FeatureSelector.py
@@ -13,7 +13,7 @@ from sklearn.model_selection import train_test_split, StratifiedKFold, KFold
 from .FeatureGenerator import *
 from concurrent.futures import ProcessPoolExecutor
 from sklearn.feature_selection import mutual_info_regression, mutual_info_classif
-from sklearn.metrics import mean_squared_error, log_loss, roc_auc_score
+from sklearn.metrics import root_mean_squared_error, log_loss, roc_auc_score
 import scipy.special
 from datetime import datetime
 import warnings
@@ -562,7 +562,7 @@ class TwoStageFeatureSelector:
             init_metric = log_loss(label, scipy.special.softmax(pred, axis=1),
                                    labels=list(range(pred.shape[1])))
         elif self.metric == 'rmse':
-            init_metric = mean_squared_error(label, pred, squared=False)
+            init_metric = root_mean_squared_error(label, pred)
         elif self.metric == 'auc':
             init_metric = roc_auc_score(label, scipy.special.expit(pred))
         else:

--- a/openfe/openfe.py
+++ b/openfe/openfe.py
@@ -11,7 +11,7 @@ import traceback
 from .utils import tree_to_formula, check_xor, formula_to_tree
 from sklearn.inspection import permutation_importance
 from sklearn.feature_selection import mutual_info_regression, mutual_info_classif
-from sklearn.metrics import mean_squared_error, log_loss, roc_auc_score
+from sklearn.metrics import root_mean_squared_error, log_loss, roc_auc_score
 import scipy.special
 from copy import deepcopy
 from tqdm import tqdm
@@ -569,7 +569,7 @@ class OpenFE:
             init_metric = log_loss(label, scipy.special.softmax(pred, axis=1),
                                    labels=list(range(pred.shape[1])))
         elif self.metric == 'rmse':
-            init_metric = mean_squared_error(label, pred, squared=False)
+            init_metric = root_mean_squared_error(label, pred)
         elif self.metric == 'auc':
             init_metric = roc_auc_score(label, scipy.special.expit(pred))
         else:


### PR DESCRIPTION
As described in [this issue](https://github.com/IIIS-Li-Group/OpenFE/issues/58#issue-2771999886) the the squared argument for the mean_squared_error function has been deprecated since scikit-learn 1.4, and removed in version 1.6, see [here](https://scikit-learn.org/1.4/modules/generated/sklearn.metrics.mean_squared_error.html).

Instead, the function root_mean_squared_error should be used, which achieves the same results and does not produce the annoying DeprecationWarning message.